### PR TITLE
remove printf from NSS.xs

### DIFF
--- a/NSS.xs
+++ b/NSS.xs
@@ -466,7 +466,7 @@ accessor(cert)
       	&subAltName);
 
     if (rv != SECSuccess) {
-    	printf("No alt name!\n");
+    	//printf("No alt name!\n");
         RETVAL = &PL_sv_no;
         return;
     } 


### PR DESCRIPTION
The printf makes post-processing STDOUT unnecessarily annoying.
